### PR TITLE
chore: update CI config to skip drafts and refine branch settings

### DIFF
--- a/.github/workflows/_pest.yml
+++ b/.github/workflows/_pest.yml
@@ -23,6 +23,7 @@ jobs:
   tests:
     name: Run
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-tests

--- a/.github/workflows/_phpstan.yml
+++ b/.github/workflows/_phpstan.yml
@@ -23,6 +23,7 @@ jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-phpstan

--- a/.github/workflows/_pint.yml
+++ b/.github/workflows/_pint.yml
@@ -23,6 +23,7 @@ jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-pint

--- a/.github/workflows/_rector.yml
+++ b/.github/workflows/_rector.yml
@@ -23,6 +23,7 @@ jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-rector

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,11 +2,10 @@ name: Continuous Integration
 
 on:
   push:
-    branches:
-      - main
+    branches: [1.x]
   pull_request:
-    branches:
-      - main
+    branches: [1.x]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,6 +15,7 @@ jobs:
   setup:
     name: Setup PHP
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     outputs:
       CACHE_KEY: ${{ steps.cache.outputs.key }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to improve CI efficiency and ensure jobs only run when appropriate. The main changes include updating branch filters, specifying pull request event types, and preventing jobs from running on draft pull requests.