### PR TITLE
fix: remove deprecated view loading for 3pontos

### DIFF
--- a/app-modules/he4rt/src/Providers/He4rtServiceProvider.php
+++ b/app-modules/he4rt/src/Providers/He4rtServiceProvider.php
@@ -13,6 +13,5 @@ class He4rtServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadViewsFrom(__DIR__.'/../../resources/views', 'he4rt');
-        $this->loadViewsFrom(__DIR__.'/../../resources/views/3pontos/views', '3pontos');
     }
 }


### PR DESCRIPTION
This pull request makes a small change to the view loading configuration in the `He4rtServiceProvider`. The code now only loads views from the main `he4rt` directory and removes the loading of views from the `3pontos` subdirectory.