### PR TITLE
fix: fallback to nickname for username during OAuth registration

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -65,7 +65,7 @@ class AppPanelProvider extends PanelProvider
                         $query = User::query();
 
                         return $query->create([
-                            'name' => $oauthUser->getName(),
+                            'name' => $oauthUser->getName() ?? $oauthUser->getNickname(),
                             'email' => $oauthUser->getEmail(),
                             'username' => $oauthUser->getNickname(),
                         ]);


### PR DESCRIPTION
Looking at the production logs, there are some errors from users that don't have names.
This PR adds a fallback value that uses the nickname as the name.