### PR TITLE
feat: add Discord logging configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "laravel/framework": "^12.41.1",
         "laravel/sanctum": "^4.2.1",
         "laravel/tinker": "^2.10.2",
+        "marvinlabs/laravel-discord-logger": "^1.4.3",
         "owenvoke/blade-fontawesome": "^3.0.0",
         "tpetry/laravel-postgresql-enhanced": "^3.5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf249d1445bd31789a3c0559dd419a94",
+    "content-hash": "19ba0cb67ef5c8bd2b284d1674ec2219",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4930,6 +4930,76 @@
             "time": "2025-09-14T11:18:39+00:00"
         },
         {
+            "name": "marvinlabs/laravel-discord-logger",
+            "version": "v1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vpratfr/laravel-discord-logger.git",
+                "reference": "b484e9742bc174920712434222f16654c343cf9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vpratfr/laravel-discord-logger/zipball/b484e9742bc174920712434222f16654c343cf9b",
+                "reference": "b484e9742bc174920712434222f16654c343cf9b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "illuminate/support": "^7.0|^8.0|^9.0|^10.0 | ^11.0 | ^12.0",
+                "php": ">=7.3 | ^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^5.0|^6.0|^8.0 | ^9.0 | ^10.0",
+                "phpunit/phpunit": "^8.0|^9.0 | ^10.5 | ^11.5.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "MarvinLabs\\DiscordLogger\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MarvinLabs\\DiscordLogger\\": "src/DiscordLogger"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Vincent Mimoun-Prat",
+                    "email": "contact@vincentprat.info",
+                    "homepage": "https://vincentprat.info",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Logging to a discord channel in Laravel",
+            "keywords": [
+                "discord",
+                "laravel",
+                "logger",
+                "logging"
+            ],
+            "support": {
+                "issues": "https://github.com/vpratfr/laravel-discord-logger/issues",
+                "source": "https://github.com/vpratfr/laravel-discord-logger/tree/v1.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/vpratfr",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-04T11:10:14+00:00"
+        },
+        {
             "name": "masterminds/html5",
             "version": "2.10.0",
             "source": {
@@ -6614,16 +6684,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.15",
+            "version": "v0.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "38953bc71491c838fcb6ebcbdc41ab7483cd549c"
+                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/38953bc71491c838fcb6ebcbdc41ab7483cd549c",
-                "reference": "38953bc71491c838fcb6ebcbdc41ab7483cd549c",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
+                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
                 "shasum": ""
             },
             "require": {
@@ -6631,8 +6701,8 @@
                 "ext-tokenizer": "*",
                 "nikic/php-parser": "^5.0 || ^4.0",
                 "php": "^8.0 || ^7.4",
-                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
-                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
+                "symfony/console": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^8.0 || ^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
             },
             "conflict": {
                 "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
@@ -6687,9 +6757,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.15"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.16"
             },
-            "time": "2025-11-28T00:00:14+00:00"
+            "time": "2025-12-07T03:39:01+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/config/discord-logger.php
+++ b/config/discord-logger.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use MarvinLabs\DiscordLogger\Converters\RichRecordConverter;
+
+return [
+
+    /*
+     * The author of the log messages. You can set both to null to keep the Webhook author set in Discord
+     */
+    'from' => [
+        'name' => env('APP_NAME', 'Laravel Logger'),
+        'avatar_url' => null,
+    ],
+
+    /**
+     * The converter to use to turn a log record into a discord message
+     *
+     * Bundled converters:
+     * - \MarvinLabs\DiscordLogger\Converters\SimpleRecordConverter::class
+     * - \MarvinLabs\DiscordLogger\Converters\RichRecordConverter::class
+     */
+    'converter' => RichRecordConverter::class,
+
+    /**
+     * If enabled, stacktraces will be attached as files. If not, stacktraces will be directly printed out in the
+     * message.
+     *
+     * Valid values are:
+     *
+     * - 'smart': when stacktrace is less than 2000 characters, it is inlined with the message, else attached as file
+     * - 'file': stacktrace is always attached as file
+     * - 'inline': stacktrace is always inlined with the message, truncated if necessary
+     */
+    'stacktrace' => 'file',
+
+    /*
+     * A set of colors to associate to the different log levels when using the `RichRecordConverter`
+     */
+    'colors' => [
+        'DEBUG' => 0x607D8B,
+        'INFO' => 0x4CAF50,
+        'NOTICE' => 0x2196F3,
+        'WARNING' => 0xFF9800,
+        'ERROR' => 0xF44336,
+        'CRITICAL' => 0xE91E63,
+        'ALERT' => 0x673AB7,
+        'EMERGENCY' => 0x9C27B0,
+    ],
+
+    /*
+     * A set of emojis to associate to the different log levels. Set to null to disable an emoji for a given level
+     */
+    'emojis' => [
+        'DEBUG' => null,
+        'INFO' => null,
+        'NOTICE' => null,
+        'WARNING' => null,
+        'ERROR' => null,
+        'CRITICAL' => null,
+        'ALERT' => null,
+        'EMERGENCY' => null,
+    ],
+];

--- a/config/logging.php
+++ b/config/logging.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use MarvinLabs\DiscordLogger\Logger;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -127,6 +128,14 @@ return [
 
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
+        ],
+
+        'discord' => [
+            'driver' => 'custom',
+            'via' => Logger::class,
+            'level' => 'debug',
+            'url' => env('LOG_DISCORD_WEBHOOK_URL'),
+            'ignore_exceptions' => env('LOG_DISCORD_IGNORE_EXCEPTIONS', false),
         ],
 
     ],


### PR DESCRIPTION
This pull request adds support for logging Laravel application events directly to Discord using the `marvinlabs/laravel-discord-logger` package.