### PR TITLE
feat: admin user panel 

### DIFF
--- a/app-modules/user/src/Filament/Admin/Resources/Users/Actions/RefreshSubmissionsAction.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Actions/RefreshSubmissionsAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Actions;
+
+use App\Models\SocialiteUser;
+use App\Models\User;
+use Filament\Actions\Action;
+use He4rt\IntegrationTwitterApi\Endpoints\AdvancedSearch\AdvancedSearchRequest;
+use He4rt\IntegrationTwitterApi\TwitterApiClient;
+use He4rt\Submission\Enums\SubmissionStatus;
+use He4rt\Submission\Models\Submission;
+use Illuminate\Support\Facades\Date;
+
+use function Illuminate\Support\hours;
+
+class RefreshSubmissionsAction extends Action
+{
+    protected function setUp(): void
+    {
+        $this->action($this->refreshSubmissions(...));
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'refresh-submissions-action';
+    }
+
+    public function refreshSubmissions(User $record): void
+    {
+        $socialiteUser = SocialiteUser::query()
+            ->where('user_id', $record->getKey())
+            ->where('provider', 'twitter')
+            ->whereNotNull('username')
+            ->first();
+
+        if (! $socialiteUser) {
+            return;
+        }
+
+        $client = resolve(TwitterApiClient::class);
+        $searchUntilDate = now()->addDay()->format('Y-m-d');
+        $payload = sprintf(
+            '(from:%s) (#100DiasDeCodigo) until:%s since:2025-11-01_10:22:00_UTC',
+            $socialiteUser->username,
+            $searchUntilDate
+        );
+        $response = cache()
+            ->remember(
+                'refresh_'.$searchUntilDate,
+                hours(10),
+                fn () => $client->advancedSearch(AdvancedSearchRequest::make($payload))
+            );
+
+        foreach ($response->tweets as $tweet) {
+            $submission = Submission::query()->where('tweet_id', $tweet->id)->first();
+
+            if (! $submission) {
+                Submission::query()->create([
+                    'user_id' => $socialiteUser->user_id,
+                    'content' => $tweet->text,
+                    'tweet_id' => $tweet->id,
+                    'status' => SubmissionStatus::Pending,
+                    'metadata' => $tweet->jsonSerialize(),
+                    'submitted_at' => Date::parse($tweet->createdAt)->timezone(config('app.timezone')),
+                ]);
+
+                continue;
+            }
+
+            $submission->update([
+                'metadata' => $tweet->jsonSerialize(),
+            ]);
+        }
+    }
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/Pages/CreateUser.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Pages/CreateUser.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use He4rt\User\Filament\Admin\Resources\Users\UserResource;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/Pages/EditUser.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Pages/EditUser.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Pages;
+
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use He4rt\User\Filament\Admin\Resources\Users\UserResource;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/Pages/ListUsers.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Pages/ListUsers.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use He4rt\User\Filament\Admin\Resources\Users\UserResource;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Schemas;
+
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class UserForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required(),
+                TextInput::make('email')
+                    ->label('Email address')
+                    ->email()
+                    ->required(),
+                TextInput::make('username')
+                    ->required(),
+                DateTimePicker::make('email_verified_at'),
+                TextInput::make('password')
+                    ->password(),
+            ]);
+    }
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/Tables/UsersTable.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Tables/UsersTable.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users\Tables;
+
+use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use He4rt\User\Filament\Admin\Resources\Users\Actions\RefreshSubmissionsAction;
+
+class UsersTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('email')
+                    ->label('Email address')
+                    ->searchable(),
+                TextColumn::make('username')
+                    ->searchable(),
+                IconColumn::make('has_twitter')
+                    ->boolean()
+                    ->state(fn ($record) => SocialiteUser::query()
+                        ->where('provider', 'twitter')
+                        ->where('user_id', $record->getKey())->exists())
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+
+            ])
+            ->recordActions([
+                RefreshSubmissionsAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app-modules/user/src/Filament/Admin/Resources/Users/UserResource.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/UserResource.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\User\Filament\Admin\Resources\Users;
+
+use App\Models\User;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use He4rt\User\Filament\Admin\Resources\Users\Pages\CreateUser;
+use He4rt\User\Filament\Admin\Resources\Users\Pages\EditUser;
+use He4rt\User\Filament\Admin\Resources\Users\Pages\ListUsers;
+use He4rt\User\Filament\Admin\Resources\Users\Schemas\UserForm;
+use He4rt\User\Filament\Admin\Resources\Users\Tables\UsersTable;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?string $recordTitleAttribute = 'username';
+
+    public static function form(Schema $schema): Schema
+    {
+        return UserForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return UsersTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'create' => CreateUser::route('/create'),
+            'edit' => EditUser::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app-modules/user/src/Providers/UserServiceProvider.php
+++ b/app-modules/user/src/Providers/UserServiceProvider.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 
 namespace He4rt\User\Providers;
 
+use Filament\Panel;
 use Illuminate\Support\ServiceProvider;
 
 class UserServiceProvider extends ServiceProvider
 {
-    public function register(): void {}
+    public function register(): void
+    {
+        Panel::configureUsing(function (Panel $panel): void {
+            if ($panel->getId() === 'admin') {
+                $panel->discoverResources(
+                    in: __DIR__.'/../Filament/Admin/Resources',
+                    for: 'He4rt\\User\\Filament\\Admin\\Resources'
+                );
+            }
+        });
+    }
 
     public function boot(): void {}
 }

--- a/app/Models/SocialiteUser.php
+++ b/app/Models/SocialiteUser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Database\Factories\SocialiteUserFactory;
 use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser as BaseSocialiteUser;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,6 +13,7 @@ use Override;
 
 class SocialiteUser extends BaseSocialiteUser
 {
+    /** @use HasFactory<SocialiteUserFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/SocialiteUser.php
+++ b/app/Models/SocialiteUser.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use DutchCodingCompany\FilamentSocialite\Models\SocialiteUser as BaseSocialiteUser;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Laravel\Socialite\Contracts\User as SocialiteUserContract;
+use Override;
+
+class SocialiteUser extends BaseSocialiteUser
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'provider_id',
+        'display_name',
+        'username',
+        'email',
+    ];
+
+    #[Override]
+    public static function createForProvider(string $provider, SocialiteUserContract $oauthUser, Authenticatable $user): self
+    {
+        return self::query()
+            ->create([
+                'user_id' => $user->getKey(),
+                'provider' => $provider,
+                'provider_id' => $oauthUser->getId(),
+                'username' => $oauthUser->getNickname(),
+                'display_name' => $oauthUser->getName(),
+                'email' => $oauthUser->getEmail() ?? '',
+            ]);
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers\Filament;
 
 use App\Filament\Shared\Pages\LoginPage;
+use App\Models\SocialiteUser;
 use App\Models\User;
 use DutchCodingCompany\FilamentSocialite\FilamentSocialitePlugin;
 use DutchCodingCompany\FilamentSocialite\Provider;
@@ -54,6 +55,7 @@ class AppPanelProvider extends PanelProvider
             ])
             ->plugins([
                 FilamentSocialitePlugin::make()
+                    ->socialiteUserModelClass(SocialiteUser::class)
                     ->registration(function ($provider): bool {
                         if (! auth()->check() && $provider === 'github') {
                             return true;

--- a/database/factories/SocialiteUserFactory.php
+++ b/database/factories/SocialiteUserFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\SocialiteUser;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * @extends Factory<SocialiteUser>
+ */
+class SocialiteUserFactory extends Factory
+{
+    protected $model = SocialiteUser::class;
+
+    public function definition(): array
+    {
+        return [
+            'provider' => fake()->word(),
+            'provider_id' => fake()->word(),
+            'created_at' => Date::now(),
+            'updated_at' => Date::now(),
+            'username' => fake()->userName(),
+            'email' => fake()->unique()->safeEmail(),
+            'display_name' => fake()->name(),
+
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2025_12_07_214752_add_provider_fields_to_socialite_users_table.php
+++ b/database/migrations/2025_12_07_214752_add_provider_fields_to_socialite_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('socialite_users', function (Blueprint $table): void {
+            $table->string('username')->nullable()->after('provider_id');
+            $table->string('email')->nullable()->after('provider_id');
+            $table->string('display_name')->nullable()->after('provider_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('socialite_users', function (Blueprint $table): void {
+            $table->dropColumn('username');
+            $table->dropColumn('email');
+            $table->dropColumn('display_name');
+        });
+    }
+};

--- a/resources/views/components/submissions/submission-entry.blade.php
+++ b/resources/views/components/submissions/submission-entry.blade.php
@@ -1,8 +1,6 @@
 @props([
     'status' => 'pending',
-    //pending,
-    complete,
-    missed'day' => 1,
+    'day' => 1,
     'date' => null,
     'submission' => null,
 ])


### PR DESCRIPTION
This pull request introduces a new Filament admin panel resource for users, including CRUD pages, table configuration, and a custom action to refresh user submissions from Twitter. It also refactors the `SocialiteUser` model, updates the related migration, and configures the FilamentSocialite plugin to use the custom model. These changes collectively improve the admin experience for managing users and their submissions, and enhance integration with social authentication providers.

### Filament Admin Panel: User Resource

* Added a complete Filament `UserResource` with form schema (`UserForm`), table schema (`UsersTable`), and CRUD pages (`ListUsers`, `CreateUser`, `EditUser`). This provides a full-featured admin interface for managing users.

### Custom Actions & Submissions Integration

* Implemented `RefreshSubmissionsAction`, allowing admins to fetch and update user submissions from Twitter, leveraging the Twitter API and caching results.

### Socialite User Model & Migration

* Created a custom `SocialiteUser` model extending the base package model, with additional fields and a helper method for provider-based creation.
* Added a migration to include `username`, `email`, and `display_name` fields in the `socialite_users` table to support richer user data.

### Filament & Service Provider Configuration

* Updated `UserServiceProvider` to auto-discover Filament resources for the admin panel.
* Configured the FilamentSocialite plugin to use the new custom `SocialiteUser` model for social authentication.

### Blade Component Fix

* Fixed a syntax error in the `submission-entry` Blade component props definition.