### PR TITLE
fix: optimize user metrics calculations

### DIFF
--- a/app-modules/portal/resources/views/components/participants/list-participants.blade.php
+++ b/app-modules/portal/resources/views/components/participants/list-participants.blade.php
@@ -28,15 +28,11 @@
             })
         },
 
-        _viewMode: $queryString('grid').usePush().as('viewMode'),
-        get viewMode() {
-            return this._viewMode
-        },
+        viewMode: localStorage.getItem('viewMode') ?? 'grid',
 
-        set viewMode(value) {
-            this._viewMode = value
-            this.$nextTick(() => {
-                this.$refs.section.scrollIntoView({ behavior: 'smooth' })
+        init() {
+            this.$watch('viewMode', (value) => {
+                localStorage.setItem('viewMode', value)
             })
         },
 
@@ -103,7 +99,7 @@
                 </div>
                 <div class="flex items-center gap-2">
                     <div
-                        class="flex flex-row items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+                        class="flex cursor-pointer flex-row items-center justify-center gap-1 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
                     >
                         <x-filament::icon icon="heroicon-o-arrows-up-down" class="me-2 h-4 w-4" x-on::click="" />
                         <select class="border-0 bg-white text-sm outline-0 dark:bg-gray-800" x-model="selectedSort">

--- a/app-modules/portal/src/Pages/ParticipantsPage.php
+++ b/app-modules/portal/src/Pages/ParticipantsPage.php
@@ -73,23 +73,25 @@ class ParticipantsPage extends Page
             ->get()
             ->map(function (User $user): array {
                 $metrics = self::calculateTwitterMetrics($user->submissions);
+                $currentStreak = $user->current_streak;
+                $totalDays = $user->total_days;
 
-                $this->totalDaysCount += $user->total_days;
+                $this->totalDaysCount += $totalDays;
 
-                if ($user->total_days >= 100) {
-                    $this->winnersCount += 1;
+                if ($totalDays >= 100) {
+                    $this->winnersCount++;
                 }
 
-                if ($user->current_streak) {
-                    $this->generalStreakCount += $user->current_streak;
+                if ($currentStreak) {
+                    $this->generalStreakCount += $currentStreak;
                 }
 
                 return [
                     'name' => $user->name,
                     'username' => $user->username,
                     'avatar' => $user->getFilamentAvatarUrl(),
-                    'total_days' => static::abbreviate($user->total_days),
-                    'current_streak' => static::abbreviate($user->current_streak),
+                    'total_days' => $totalDays,
+                    'current_streak' => $currentStreak,
                     'tags' => ['#php', '#vibecoding', '#laravel', 'alpine.js', '#fullstack'],
                     'twitter_metrics' => [
                         'likes' => static::abbreviate($metrics['likes']),


### PR DESCRIPTION
- This PR introduces an optimization in mount method. Each usage of `$user->total_days` and `$user->current_streak` make database queries, so I made a refactor to do only one usage of these methods per iteration on map method.
- I also made a change into list-participant component, removing `queryString ` and using `localStorage` instead to set the page view mode