### PR TITLE
feat: implement custom logout response and register service provider

### DIFF
--- a/app/Filament/Shared/Responses/LogoutResponse.php
+++ b/app/Filament/Shared/Responses/LogoutResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Shared\Responses;
+
+use Illuminate\Http\RedirectResponse;
+
+class LogoutResponse implements \Filament\Auth\Http\Responses\Contracts\LogoutResponse
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function toResponse($request): RedirectResponse
+    {
+        return to_route('filament.guest.pages.portal-page');
+    }
+}

--- a/app/Providers/Filament/GuestPanelProvider.php
+++ b/app/Providers/Filament/GuestPanelProvider.php
@@ -35,11 +35,11 @@ class GuestPanelProvider extends PanelProvider
                 'primary' => Color::Purple,
             ])
             ->topNavigation()
-            ->renderHook(PanelsRenderHook::TOPBAR_END, fn () => Blade::render(<<<'BLADE'
-                @guest
-                    <x-he4rt::button href="/app" icon-position="leading" icon="heroicon-o-user">Acessar Plataforma</x-he4rt::button>
-                @endguest
-            BLADE
+            ->renderHook(PanelsRenderHook::TOPBAR_END, fn () => Blade::render(<<<'HTML'
+                    @guest
+                        <x-he4rt::button href="/app" icon-position="leading" icon="heroicon-o-user">Acessar Plataforma</x-he4rt::button>
+                    @endguest
+                HTML
             ))
             ->pages([
                 PortalPage::class,

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Filament\Shared\Responses\LogoutResponse as LogoutResponseImpl;
+use Filament\Auth\Http\Responses\Contracts\LogoutResponse as LogoutResponseContract;
+use Illuminate\Support\ServiceProvider;
+
+class FilamentServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(LogoutResponseContract::class, LogoutResponseImpl::class);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -6,9 +6,11 @@ use App\Providers\AppServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Providers\Filament\AppPanelProvider;
 use App\Providers\Filament\GuestPanelProvider;
+use App\Providers\FilamentServiceProvider;
 
 return [
     AppServiceProvider::class,
+    FilamentServiceProvider::class,
     AdminPanelProvider::class,
     AppPanelProvider::class,
     GuestPanelProvider::class,


### PR DESCRIPTION
This pull request introduces a custom logout response for Filament and ensures it is properly registered and used throughout the application. The main changes include implementing the custom response, binding it to the Filament contract, and updating the service provider registration.

**Custom Logout Response Implementation:**

- Added a new `LogoutResponse` class in `app/Filament/Shared/Responses/LogoutResponse.php` that implements Filament's logout response contract and redirects users to the `filament.guest.pages.portal-page` route after logout.

**Service Provider Registration:**

- Created a new `FilamentServiceProvider` in `app/Providers/FilamentServiceProvider.php` that binds the Filament logout response contract to the custom `LogoutResponse` implementation.
- Registered the new `FilamentServiceProvider` in `bootstrap/providers.php` to ensure the binding is active in the application lifecycle.

**Minor Blade Template Update:**

- Changed the heredoc label from `BLADE` to `HTML` in the guest panel provider's `renderHook` call for clarity and consistency.